### PR TITLE
chore: release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/esmevane/markdown-walker/releases/tag/v0.0.1) - 2025-01-02
+
+### Other
+
+- add release-plz
+- doc test.
+- Trait, license, docs.
+- Ex nihilo.


### PR DESCRIPTION
## 🤖 New release
* `markdown-walker`: 0.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.1](https://github.com/esmevane/markdown-walker/releases/tag/v0.0.1) - 2025-01-02

### Other

- add release-plz
- doc test.
- Trait, license, docs.
- Ex nihilo.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).